### PR TITLE
fix: install powerlevel10k to themes/ not plugins/

### DIFF
--- a/Setupfile
+++ b/Setupfile
@@ -13,7 +13,6 @@ gitignore "linux,swift,xcode,macos,objective-c,visualstudiocode"
 plugin "zsh-syntax-highlighting" "https://github.com/zsh-users/zsh-syntax-highlighting"  # Syntax highlighting for Zsh
 plugin "zsh-autosuggestions"     "https://github.com/zsh-users/zsh-autosuggestions"      # Fish-like autosuggestions
 plugin "zsh-completions"         "https://github.com/zsh-users/zsh-completions"          # Additional completion definitions
-plugin "powerlevel10k"           "https://github.com/romkatv/powerlevel10k"              # Powerlevel10k theme
 brew   "wget"                                   # Download files from the web
 brew   "nmap"                                   # Network exploration and port scanner
 cask   "iterm2"                                 # Terminal emulator for macOS

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,7 +29,12 @@ _install_plugin() {
     return
   fi
 
-  local dest="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/$name"
+  local dest
+  if [[ "$name" == "powerlevel10k" ]]; then
+    dest="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/$name"
+  else
+    dest="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/$name"
+  fi
   if [[ ! -d "$dest" ]]; then
     git clone --depth=1 "$url" "$dest"
   else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,12 +29,7 @@ _install_plugin() {
     return
   fi
 
-  local dest
-  if [[ "$name" == "powerlevel10k" ]]; then
-    dest="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/$name"
-  else
-    dest="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/$name"
-  fi
+  local dest="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/$name"
   if [[ ! -d "$dest" ]]; then
     git clone --depth=1 "$url" "$dest"
   else
@@ -43,6 +38,38 @@ _install_plugin() {
 
   ZSH_PLUGIN_NAMES+=("$name")
 }
+
+_install_theme() {
+  local name="$1"
+  local url="${2:-}"
+
+  if [[ -z "$url" ]]; then
+    echo "Warning: no URL provided for theme '$name' — skipping" >&2
+    return
+  fi
+
+  local dest="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/$name"
+  if [[ ! -d "$dest" ]]; then
+    git clone --depth=1 "$url" "$dest"
+  else
+    echo "Theme '$name' already installed, skipping clone."
+  fi
+
+  local theme_line="ZSH_THEME=\"$name/$name\""
+  touch "$HOME/.zshrc"
+  if grep -q '^ZSH_THEME=' "$HOME/.zshrc"; then
+    local tmp
+    tmp=$(mktemp)
+    sed "s|^ZSH_THEME=.*|$theme_line|" "$HOME/.zshrc" > "$tmp"
+    cat "$tmp" > "$HOME/.zshrc"
+    rm "$tmp"
+  else
+    echo "$theme_line" >> "$HOME/.zshrc"
+  fi
+}
+
+echo "Installing theme: powerlevel10k"
+_install_theme "powerlevel10k" "https://github.com/romkatv/powerlevel10k"
 
 while IFS= read -r line; do
   # Skip blank lines and comments


### PR DESCRIPTION
ZSH_THEME="powerlevel10k/powerlevel10k" expects the theme in
~/.oh-my-zsh/custom/themes/. The _install_plugin function was
installing it to plugins/ instead, causing zsh to fail on first launch.